### PR TITLE
Added Google Analytics tracking to page layouts.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,6 +22,8 @@ socials:
 
 copyright: '&copy; 2025. All rights reserved.'
 
+ga: G-XXXXXXXXXX # Your Google Analytics tracking ID
+
 
 # These attributes are required for theme highlighting, only overwrite if you
 # know what you're doing.

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -7,6 +7,13 @@
 -->
 <html>
 	<head>
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.ga }}"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', '{{ site.ga }}');
+    </script>
     <title>{{ title }}</title>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />

--- a/tessellate.gemspec
+++ b/tessellate.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "tessellate"
-  spec.version       = "0.1.15"
+  spec.version       = "0.1.16"
   spec.authors       = ["Preston Hager"]
   spec.email         = ["preston@hagerfamily.com"]
 


### PR DESCRIPTION
This pull request adds Google Analytics support to the site and updates the gem version. The most important changes are grouped below:

Analytics Integration:

* Added a `ga` field for the Google Analytics tracking ID in `_config.yml`.
* Inserted Google Analytics tracking script into the `<head>` section of `_layouts/page.html` to enable site analytics.

Version Bump:

* Updated the gem version in `tessellate.gemspec` from `0.1.15` to `0.1.16`.